### PR TITLE
add readthedocs config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,6 @@ jobs:
         if: failure()
         with:
           path: "*.*"
-      - name: Build documentation
-        if: runner.os == 'Linux'
-        run: cd docs && make && touch _build/html/.nojekyll
-      - name: Deploy documentation
-        uses: JamesIves/github-pages-deploy-action@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && runner.os == 'Linux' && matrix.python-version == '3.8'
-        with:
-          branch: gh-pages
-          folder: docs/_build/html
-          single-commit: true
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,56 @@
+## NOTE: the environment variable DISPLAY=:0 is set in the readthedocs web user interface!
+## This is required for pyglet to work with xvfb, and apparently cannot be set here
+
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+  apt_packages:
+    # system dependencies of wxPython wheel
+    - libnotify-dev
+    - libsdl2-dev
+    # xvfb to run a virtual display
+    - xvfb
+    # mesa drivers for opengl
+    - mesa-common-dev
+    - mesa-utils
+    # system sound driver for sounddevice
+    - libportaudio2
+  jobs:
+    pre_install:
+      # install pre-built ubuntu/gtk3 wxPython wheel
+      - python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython
+      # check if any required system libs are missing by trying to import it
+      - python -c "import wx"
+      # create virtual display for pyglet
+      - echo $DISPLAY
+      - Xvfb -ac +extension GLX +render -screen 0 1024x768x24 $DISPLAY &
+      # check xvfb is working
+      - xdpyinfo -display $DISPLAY
+      # check opengl is working
+      - LIBGL_DEBUG=verbose glxinfo -v -B
+    post_install:
+      # psychtoolbox is installed by psychopy but is actually optional and only used if available
+      # it requires python to have permission to set its priority level otherwise it exits with an error
+      # since this requires sudo we instead remove psychtoolbox
+      - python -m pip uninstall -yy psychtoolbox
+      # check pyglet is working
+      - python -m pyglet.info
+      # check we can import vstt
+      - python -c "import vstt; print(vstt.__version__)"
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+formats:
+  - pdf
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Visuomotor Serial Targeting Task (VSTT)
 
+[![Docs](https://readthedocs.org/projects/vstt/badge/?version=latest)](https://vstt.readthedocs.io/en/latest/?badge=latest)
 [![CI](https://github.com/ssciwr/vstt/actions/workflows/ci.yml/badge.svg)](https://github.com/ssciwr/vstt/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ssciwr/vstt/branch/main/graph/badge.svg?token=sjsAdTyLH1)](https://codecov.io/gh/ssciwr/vstt)
+[![Coverage](https://codecov.io/gh/ssciwr/vstt/branch/main/graph/badge.svg?token=sjsAdTyLH1)](https://codecov.io/gh/ssciwr/vstt)
 
 Visuomotor Serial Targeting Task (VSTT)
 
-Documentation: [ssciwr.github.io/vstt](https://ssciwr.github.io/vstt/)
+Documentation: [vstt.readthedocs.io](https://vstt.readthedocs.io/)
 
 ![screenshot](https://raw.githubusercontent.com/ssciwr/vstt/main/docs/quickstart/images/gui.png)
 ![screenshot](https://raw.githubusercontent.com/ssciwr/vstt/main/docs/quickstart/images/results.png)


### PR DESCRIPTION
- installs pre-built wxPython wheel & associated required system libs
- installs xvfb for a virtual display
  - create 24bit screen as default 8bit screen not supported by opengl
  - IMPORTANT: `DISPLAY=:0` env var is set in *web UI*
- installs mesa for software opengl support
- installs libportaudio2 for sounddevice support
- removes psychtoolbox after installing vstt to avoid psychtoolbox needing sudo issue
- resolves https://github.com/ssciwr/vstt/issues/62