### PR TITLE
Improve accuracy of timestamps

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,6 @@ Visuomotor Serial Targeting Task (VSTT)
 =======================================
 
 .. toctree::
-   :maxdepth: 2
    :caption: Getting started
 
    quickstart/install
@@ -12,7 +11,12 @@ Visuomotor Serial Targeting Task (VSTT)
    quickstart/share-experiment
 
 .. toctree::
-   :maxdepth: 2
+   :caption: Reference information
+
+   reference/statistics
+   reference/framerate
+
+.. toctree::
    :caption: Example jupyter notebooks
 
    notebooks/example
@@ -20,7 +24,6 @@ Visuomotor Serial Targeting Task (VSTT)
    notebooks/area_calculation
 
 .. toctree::
-   :maxdepth: 2
    :caption: Developer documentation
 
    developer/install

--- a/docs/reference/framerate.rst
+++ b/docs/reference/framerate.rst
@@ -1,0 +1,37 @@
+Framerates and timestamps
+=========================
+
+Introduction
+------------
+
+During an experiment you see the cursor moving on the screen, but what your screen actually displays
+is a series of still images, or frames, which are updated quickly enough that we don't notice the individual frames.
+
+Typically computer monitors do this at a rate of 60 frames per second (fps), although gaming monitors are available
+that offer much higher refresh rates.
+
+The experiment saves information about the cursor position each time a new frame is displayed.
+
+How an experiment works
+-----------------------
+
+This loop happens every time the monitor refreshes:
+
+   - store the timestamp and current cursor location
+   - prepare next frame to display (draw objects such as the cursor, targets, etc)
+   - wait until the screen is updated with the new frame
+
+In the stored data, each timestamp is the time when the specified target was displayed on the screen,
+and the cursor location at that time. The display on the screen doesn't change until the next timestamp.
+
+Dropped frames
+--------------
+
+The sampling frequency of the experimental data is limited by the refresh rate of the monitor.
+
+In addition, it could sometimes be the case that the code preparing the next frame to be displayed takes too long,
+and the monitor refreshes the screen before the next frame is available.
+This is known as a "dropped frame", and will be visible in the recorded data as a larger than usual delay
+before the next timestamp.
+
+If this happens, ensuring that nothing else is running on the computer when an experiment is running may help.

--- a/docs/reference/statistics.rst
+++ b/docs/reference/statistics.rst
@@ -1,0 +1,20 @@
+Statistics
+==========
+
+Time
+----
+
+   * Time
+      * Time from target being displayed to the target being reached by the cursor or timeout
+   * Reaction time
+      * Time from target being displayed to first cursor movement
+   * Movement time
+      * Time from first cursor movement to the target being reached by the cursor or timeout
+
+Distance
+--------
+
+   * Distance
+      * Euclidean point-to-point distance travelled by the cursor
+   * RMSE
+      * The Root Mean Square Error (RMSE) of the perpendicular distance from each cursor point to the ideal path to the target

--- a/src/vstt/__init__.py
+++ b/src/vstt/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/src/vstt/gui.py
+++ b/src/vstt/gui.py
@@ -80,6 +80,7 @@ class Gui(QtWidgets.QMainWindow):
             self.experiment.load_file(filename)
         except Exception as e:
             logging.warning(f"Failed to load file {filename}: {e}")
+            logging.exception(e)
             QtWidgets.QMessageBox.critical(
                 self,
                 "Invalid file",

--- a/src/vstt/task.py
+++ b/src/vstt/task.py
@@ -47,7 +47,9 @@ class TrialData:
             rng.shuffle(self.target_indices)
         self.target_pos: List[np.ndarray] = []
         self.to_target_timestamps: List[np.ndarray] = []
+        self.to_target_num_timestamps_before_visible: List[int] = []
         self.to_center_timestamps: List[np.ndarray] = []
+        self.to_center_num_timestamps_before_visible: List[int] = []
         self.to_target_mouse_positions: List[np.ndarray] = []
         self.to_center_mouse_positions: List[np.ndarray] = []
         self.to_target_success: List[bool] = []
@@ -91,6 +93,7 @@ class TrialManager:
         self.prev_cursor_path = ShapeStim(
             win, vertices=[(0, 0)], lineColor="white", closeShape=False
         )
+        self.clock = Clock()
         if trial["show_cursor_path"]:
             self.drawables.append(self.cursor_path)
             self.drawables.append(self.prev_cursor_path)
@@ -179,11 +182,11 @@ class MotorTask:
             == trial["weight"]
         )
         self.mouse.setPos(tom.cursor.pos)
-        previous_target_time_taken = 0.0
+        self.win.recordFrameIntervals = True
+        tom.clock.reset()
         for index in tom.data.target_indices:
-            previous_target_time_taken = self._do_target(
-                trial, index, tom, previous_target_time_taken
-            )
+            self._do_target(trial, index, tom)
+        self.win.recordFrameIntervals = False
 
         if trial["automove_cursor_to_center"]:
             tom.data.to_center_success = [True] * trial["num_targets"]
@@ -211,31 +214,23 @@ class MotorTask:
                 self.win,
             )
 
-    def _do_target(
-        self,
-        trial: Dict[str, Any],
-        index: int,
-        tm: TrialManager,
-        previous_target_time_taken: float,
-    ) -> float:
-        clock = Clock()
+    def _do_target(self, trial: Dict[str, Any], index: int, tm: TrialManager) -> None:
+        minimum_window_for_flip = 1.0 / 60.0
         mouse_pos = tm.cursor.pos
-        current_target_time_taken = 0
+        stop_waiting_time = 0.0
+        stop_target_time = 0.0
+        if trial["fixed_target_intervals"]:
+            num_completed_targets = len(tm.data.to_target_timestamps)
+            stop_waiting_time = (num_completed_targets + 1) * trial["target_duration"]
+            stop_target_time = stop_waiting_time + trial["target_duration"]
         for target_index in _get_target_indices(index, trial):
-            # no target displayed
-            vis.update_target_colors(tm.targets, trial["show_inactive_targets"], None)
-            if trial["show_target_labels"]:
-                vis.update_target_label_colors(
-                    tm.target_labels, trial["show_inactive_targets"], None
-                )
+            t0 = tm.clock.getTime()
+            is_central_target = target_index == trial["num_targets"]
             mouse_times = []
             mouse_positions = []
-            is_central_target = target_index == trial["num_targets"]
             if is_central_target:
-                mouse_times = [0]
-                mouse_positions = [tm.cursor_path.vertices[-1]]
                 tm.prev_cursor_path.vertices = tm.cursor_path.vertices
-                tm.cursor_path.vertices = mouse_positions
+                tm.cursor_path.vertices = [tm.cursor_path.vertices[-1]]
             else:
                 if trial["automove_cursor_to_center"]:
                     mouse_pos = np.array([0.0, 0.0])
@@ -243,28 +238,42 @@ class MotorTask:
                     tm.cursor.setPos(mouse_pos)
                 tm.cursor_path.vertices = [mouse_pos]
                 tm.prev_cursor_path.vertices = [(0, 0)]
-                clock.reset()
-                wait_time = trial["inter_target_duration"]
-                if trial["fixed_target_intervals"]:
-                    wait_time = trial["target_duration"] - previous_target_time_taken
-                while clock.getTime() < wait_time:
-                    if trial["freeze_cursor_between_targets"]:
-                        self.mouse.setPos(mouse_pos)
-                    else:
-                        if trial["use_joystick"]:
-                            mouse_pos = tm.joystick_point_updater(
-                                mouse_pos, (self.js.getX(), self.js.getY())  # type: ignore
-                            )
-                        else:
-                            mouse_pos = tm.point_rotator(self.mouse.getPos())
-                    mouse_times.append(clock.getTime() - wait_time)
-                    mouse_positions.append(mouse_pos)
-                    if trial["show_cursor"]:
-                        tm.cursor.setPos(mouse_pos)
-                    if trial["show_cursor_path"]:
-                        tm.cursor_path.vertices = mouse_positions
-                    vis.draw_and_flip(self.win, tm.drawables, self.kb)
+                if not trial["fixed_target_intervals"]:
+                    stop_waiting_time = t0 + trial["inter_target_duration"]
+                if stop_waiting_time > t0:
+                    # no target displayed
+                    vis.update_target_colors(
+                        tm.targets, trial["show_inactive_targets"], None
+                    )
+                    if trial["show_target_labels"]:
+                        vis.update_target_label_colors(
+                            tm.target_labels, trial["show_inactive_targets"], None
+                        )
+                    # ensure we get at least a single flip
+                    should_continue_waiting = True
+                    while should_continue_waiting:
+                        if trial["freeze_cursor_between_targets"]:
+                            self.mouse.setPos(mouse_pos)
+                        vis.draw_and_flip(self.win, tm.drawables, self.kb)
+                        if not trial["freeze_cursor_between_targets"]:
+                            if trial["use_joystick"]:
+                                mouse_pos = tm.joystick_point_updater(
+                                    mouse_pos, (self.js.getX(), self.js.getY())  # type: ignore
+                                )
+                            else:
+                                mouse_pos = tm.point_rotator(self.mouse.getPos())
+                        mouse_times.append(tm.clock.getTime())
+                        mouse_positions.append(mouse_pos)
+                        if trial["show_cursor"]:
+                            tm.cursor.setPos(mouse_pos)
+                        if trial["show_cursor_path"]:
+                            tm.cursor_path.vertices = mouse_positions
+                        should_continue_waiting = (
+                            tm.clock.getTime() + minimum_window_for_flip
+                            < stop_waiting_time
+                        )
             # display current target
+            t0 = tm.clock.getTime()
             vis.update_target_colors(
                 tm.targets, trial["show_inactive_targets"], target_index
             )
@@ -274,27 +283,21 @@ class MotorTask:
                 )
             if trial["play_sound"]:
                 Sound("A", secs=0.3, blockSize=1024, stereo=True).play()
-            if not is_central_target:
-                tm.data.target_pos.append(tm.targets.xys[target_index])
-            dist_correct, dist_any = to_target_dists(
-                mouse_pos,
-                tm.targets.xys,
-                target_index,
-                trial["add_central_target"],
-            )
-            if trial["ignore_incorrect_targets"] or is_central_target:
-                dist = dist_correct
+            if is_central_target:
+                tm.data.to_center_num_timestamps_before_visible.append(len(mouse_times))
             else:
-                dist = dist_any
-            clock.reset()
-            self.win.recordFrameIntervals = True
+                tm.data.target_pos.append(tm.targets.xys[target_index])
+                tm.data.to_target_num_timestamps_before_visible.append(len(mouse_times))
             target_size = trial["target_size"]
             if is_central_target:
                 target_size = trial["central_target_size"]
-            max_time = trial["target_duration"]
-            if trial["fixed_target_intervals"]:
-                max_time -= current_target_time_taken
-            while dist > target_size and clock.getTime() < max_time:
+            if not trial["fixed_target_intervals"]:
+                stop_target_time = t0 + trial["target_duration"]
+            dist_correct = 1.0
+            # ensure we get at least one flip
+            should_continue_target = True
+            while should_continue_target:
+                vis.draw_and_flip(self.win, tm.drawables, self.kb)
                 if trial["use_joystick"]:
                     mouse_pos = tm.joystick_point_updater(
                         mouse_pos, (self.js.getX(), self.js.getY())  # type: ignore
@@ -303,7 +306,7 @@ class MotorTask:
                     mouse_pos = tm.point_rotator(self.mouse.getPos())
                 if trial["show_cursor"]:
                     tm.cursor.setPos(mouse_pos)
-                mouse_times.append(clock.getTime())
+                mouse_times.append(tm.clock.getTime())
                 mouse_positions.append(mouse_pos)
                 if trial["show_cursor_path"]:
                     tm.cursor_path.vertices = mouse_positions
@@ -317,10 +320,14 @@ class MotorTask:
                     dist = dist_correct
                 else:
                     dist = dist_any
-                vis.draw_and_flip(self.win, tm.drawables, self.kb)
-            current_target_time_taken += clock.getTime()
-            self.win.recordFrameIntervals = False
-            success = dist_correct <= target_size and clock.getTime() < max_time
+                should_continue_target = (
+                    dist > target_size
+                    and tm.clock.getTime() + minimum_window_for_flip < stop_target_time
+                )
+            success = (
+                dist_correct <= target_size
+                and tm.clock.getTime() + minimum_window_for_flip < stop_target_time
+            )
             if is_central_target:
                 tm.data.to_center_success.append(success)
             else:
@@ -331,7 +338,6 @@ class MotorTask:
             else:
                 tm.data.to_target_timestamps.append(np.array(mouse_times))
                 tm.data.to_target_mouse_positions.append(np.array(mouse_positions))
-        return current_target_time_taken
 
     def _clean_up_and_return(self, return_value: bool) -> bool:
         if self.win is not None and self.close_window_when_done:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,8 @@ def make_mouse_positions(
     return np.array([(pos[0] * t + noise(), pos[1] * t + noise()) for t in time_points])
 
 
-def make_timestamps(n_min: int = 8, n_max: int = 20) -> np.ndarray:
-    return np.linspace(0.0, 1.0, np.random.randint(n_min, n_max))
+def make_timestamps(t0: float, n_min: int = 8, n_max: int = 20) -> np.ndarray:
+    return np.linspace(t0, t0 + 1.0, np.random.randint(n_min, n_max))
 
 
 @pytest.fixture
@@ -122,18 +122,21 @@ def experiment_with_results() -> Experiment:
         target_pos = points_on_circle(
             trial["num_targets"], trial["target_distance"], include_centre=False
         )
+        t0 = 0.0
         for pos in target_pos:
-            to_target_timestamps.append(make_timestamps())
+            to_target_timestamps.append(make_timestamps(t0))
             to_target_mouse_positions.append(
                 make_mouse_positions(pos, to_target_timestamps[-1])
             )
             to_target_success.append(True)
+            t0 = to_target_timestamps[-1][-1] + 1.0 / 60.0
             if not trial["automove_cursor_to_center"]:
-                to_center_timestamps.append(make_timestamps())
+                to_center_timestamps.append(make_timestamps(t0))
                 to_center_mouse_positions.append(
                     list(reversed(make_mouse_positions(pos, to_center_timestamps[-1])))
                 )
                 to_center_success.append(True)
+                t0 = to_center_timestamps[-1][-1] + 1.0 / 60.0
         trial_handler.addData("target_indices", np.array(range(len(target_pos))))
         trial_handler.addData("target_pos", np.array(target_pos))
         trial_handler.addData(

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -231,13 +231,9 @@ def test_experiment_to_excel_trial_data_format(
             if dest is not None:
                 # target data from target display time
                 # get correct timestamps
-                ts = stats[f"to_{dest}_timestamps"][i_row]
-                # exclude any negative times from before target display
-                ts_correct = ts[ts >= 0]
+                ts_correct = stats[f"to_{dest}_timestamps"][i_row]
                 # get imported timestamps
                 ts = df_target.timestamps.to_numpy()
-                # subtract first timepoint to reset any offset to zero
-                ts = ts - ts[0]
                 assert np.allclose(ts, ts_correct)
                 # get correct mouse positions
                 xys = stats[f"to_{dest}_mouse_positions"][i_row]

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -75,12 +75,15 @@ def test_reaction_movement_time() -> None:
     ]:
         n = len(times)
         for n_zeros in range(1, n):
-            positions = [[-1e-13, 1e-14]] * n_zeros + [[1, 1]] * (n - n_zeros)
-            reaction_time = times[n_zeros]
-            assert np.allclose(
-                vstt.stat._reaction_time(np.array(times), np.array(positions)),
-                [reaction_time],
-            )
+            for n_before_visible in range(1, n):
+                positions = [[-1e-13, 1e-14]] * n_zeros + [[1, 1]] * (n - n_zeros)
+                reaction_time = times[n_zeros] - times[n_before_visible]
+                assert np.allclose(
+                    vstt.stat._reaction_time(
+                        np.array(times), np.array(positions), n_before_visible
+                    ),
+                    [reaction_time],
+                )
 
 
 def test_rmse() -> None:


### PR DESCRIPTION
- use a single clock per trial starting from zero
  - removes possibility of timestamps `fixed_target_intervals` drifting due to accumulated error
  - resolves #198
- simplify logic and the conversion to excel timestamps
- add `to_target_num_timestamps_before_visible` int to trial data (and similarly for center)
  - this is the number of to_target_timestamps for which the target is not yet visible
  - previously this was implictly defined by these timestamps having negative values
- all timestamps are now taken directly after `window.flip()` returns
  - this means the time is when the current frame was displayed (+maybe a few microseconds)
  - and this frame remains displayed until the next timestamp
  - previously we timestamped when we called `flip()` (which we control precisely)
    - but this meant the frame was actually displayed stochastically [0-1/fps) seconds after the timestamp
- require at least 1/60s remaining before timeout to call flip()
- bump version to 0.28.0

Document changes to frames / timestamp data

- add reference info section
  - framerate page
  - statistics page
- resolves #194

Ensure there is always at least one window flip when we show a new target

- we now get at least a single frame of data for each target
  - even if user is already at the target when it is displayed
- resolves #193

Minor performance improvement

- only set up drawables for "no target visible" if this will be displayed for a non-zero amount of time
