### PR TITLE
Add optional timeout for a set of conditions

### DIFF
--- a/src/vstt/trial.py
+++ b/src/vstt/trial.py
@@ -16,6 +16,9 @@ from vstt.vtypes import Trial
 def describe_trial(trial: Trial) -> str:
     repeats = f"{trial['weight']} repeat{'s' if trial['weight'] > 1 else ''}"
     targets = f"target{'s' if trial['num_targets'] > 1 else ''}"
+    if trial["condition_timeout"] > 0.0:
+        repeats = f"up to {repeats}"
+        targets = f"{targets} in {trial['condition_timeout']}s"
     return f"{repeats} of {trial['num_targets']} {trial['target_order']} {targets}"
 
 
@@ -26,6 +29,7 @@ def describe_trials(trials: List[Trial]) -> str:
 def default_trial() -> Trial:
     return {
         "weight": 1,
+        "condition_timeout": 0.0,
         "num_targets": 8,
         "target_order": "clockwise",
         "target_indices": "0 1 2 3 4 5 6 7",
@@ -62,6 +66,7 @@ def default_trial() -> Trial:
 def trial_labels() -> Dict:
     return {
         "weight": "Repetitions",
+        "condition_timeout": "Maximum time, 0=unlimited (secs)",
         "num_targets": "Number of targets",
         "target_order": "Target order",
         "target_indices": "Target indices",
@@ -119,6 +124,7 @@ def import_and_validate_trial(trial_or_dict: Mapping[str, Any]) -> Trial:
     trial = import_typed_dict(trial_or_dict, default_trial())
     # make any negative time durations zero
     for duration in [
+        "condition_timeout",
         "target_duration",
         "central_target_duration",
         "inter_target_duration",

--- a/src/vstt/update.py
+++ b/src/vstt/update.py
@@ -21,7 +21,7 @@ def _get_latest_pypi_version() -> version.Version:
 
 def check_for_new_version() -> Tuple[bool, str]:
     try:
-        current_version = version.parse(vstt.__version__)
+        current_version = version.Version(vstt.__version__)
         logging.info(f"Current version: {current_version}")
         latest_version = _get_latest_pypi_version()
         logging.info(f"Latest version: {latest_version}")

--- a/src/vstt/vtypes.py
+++ b/src/vstt/vtypes.py
@@ -12,6 +12,7 @@ else:
 
 class Trial(TypedDict):
     weight: int
+    condition_timeout: float
     num_targets: int
     target_order: Union[str, List]
     target_indices: str

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -47,6 +47,7 @@ def test_import_trial() -> None:
     default_trial = vstt.trial.default_trial()
     trial_dict = {
         "weight": 2,
+        "condition_timeout": 0,
         "num_targets": 6,
         "target_order": "clockwise",
         "target_indices": "0 1 2 3 4 5",
@@ -78,6 +79,9 @@ def test_import_trial() -> None:
         "show_delay_countdown": False,
         "enter_to_skip_delay": True,
     }
+    # start with a dict containing valid values for all keys
+    for key in default_trial:
+        assert key in trial_dict
     # all valid keys are imported
     trial = vstt.trial.import_and_validate_trial(trial_dict)
     for key in trial:


### PR DESCRIPTION
Add optional timeout for a set of conditions

- add `condition_timeout` to trial settings
- if `0` (default value) there is no timeout
  - i.e. no change to existing behaviour
- if non-zero
  - trials for this condition will stop after this time in seconds has elapsed
  - if a trial is in progress when timeout occurs it is allowed to complete
  - all subsequent trials from this condition are skipped
- update descriptions of trials to include timeout if present
- update stats / GUI to deal with missing data in trialhandler
- resolves #152
