### PR TITLE
Add buttons to save image of results visualization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "click",
   "PyQt5",
   "requests",
-  "packaging"
+  "packaging",
+  "pillow"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
- Add `Trial Image` and `Condition Image` buttons to results widget
  - Screenshots visualization of results
  - Prompts user for a filename to save the screenshot as a png image
- Add `return_screenshot` bool arg to `display_drawables` and `display_results`
  - If true, do a single flip and then return image of window
  - Default: `false`
- resolves #226