### PR TITLE
Enable display of to center paths by default

### DIFF
--- a/src/vstt/display.py
+++ b/src/vstt/display.py
@@ -8,7 +8,7 @@ import vstt
 def default_display_options() -> vstt.vtypes.DisplayOptions:
     return {
         "to_target_paths": True,
-        "to_center_paths": False,
+        "to_center_paths": True,
         "targets": True,
         "central_target": True,
         "to_target_reaction_time": True,


### PR DESCRIPTION
- makes more sense to enable this now as default trial no longer auto-moves back to center