### PR TITLE
Fix fixed target display intervals additional delay bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - os: "ubuntu-22.04"
             python-version: "3.10"
-            psychopy-version: "2023.2.2"
+            psychopy-version: "2023.2.3"
           - os: "ubuntu-22.04"
             python-version: "3.10"
             psychopy-version: "2023.1.3"
@@ -50,7 +50,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           # various psychopy & qt system dependencies
-          sudo apt-get update -yy && sudo apt-get install -yy libasound2-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev libsndfile1-dev libportmidi-dev liblo-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0 freeglut3-dev scrot libnotify-dev pandoc libglu1-mesa-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev '^libxcb.*-dev'
+          sudo apt-get update -yy && sudo apt-get install -yy libasound2-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev libsndfile1-dev libportmidi-dev liblo-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0 freeglut3-dev scrot libnotify-dev pandoc libglu1-mesa-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxkbcommon-dev libxkbcommon-x11-dev '^libxcb.*-dev' gnome-screenshot
           # install pre-built ubuntu/gtk3 wxPython wheel
           pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}/ wxPython
           # enable colours in logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.3.2] - 2023-12-08
+
+### Fixed
+
+- additional delay between repetitions of a condition when using fixed target display intervals [#256](https://github.com/ssciwr/vstt/issues/256)
+
+## [1.3.1] - 2023-11-06
+
+### Fixed
+
+- missing dependency for vstt 1.3.0 [#254](https://github.com/ssciwr/vstt/pull/254)
+
 ## [1.3.0] - 2023-09-29
 
 ### Added

--- a/src/vstt/__init__.py
+++ b/src/vstt/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"


### PR DESCRIPTION
- repeat of condition with `fixed target display intervals` now continues the same fixed intervals
  - previously the time from the last target of the previous trial was not taken into account
  - this meant the first target of each repeat had a longer delay than desired
- store the time used by most recent target for current / previous trial in `TaskManager` to allow this
- extend `test_task_fixed_intervals_no_user_input` to include this case in tests
- bump version to 1.3.2
- update changelog
- resolves #256
