### PR TITLE
Restrict the value of 2 variables "window-length" and "polyorder" in the example, set the numpy version < 2.0.0 in pyproject.toml

### DIFF
--- a/docs/notebooks/path_and_velocity.ipynb
+++ b/docs/notebooks/path_and_velocity.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "import warnings\n",
     "\n",
+    "import ipywidgets as widgets\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import vstt\n",
@@ -322,7 +323,11 @@
     "    plt.show()\n",
     "\n",
     "\n",
-    "interact(plot_filter, window_length=30, polyorder=8);"
+    "interact(\n",
+    "    plot_filter,\n",
+    "    window_length=widgets.IntSlider(min=1, max=40, step=1, value=40),\n",
+    "    polyorder=widgets.IntSlider(min=1, max=40, step=1, value=8),\n",
+    ");"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "numpy",
+  "numpy<2.0.0",
   "packaging",
   "pillow",
   "psychopy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
   "pandoc",
   "sphinx>=4.5.0",
   "sphinx_rtd_theme>=1.0.0",
+  "ipywidgets",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
1. Restrict the value of 2 variables "window-length" and "polyorder" in the example;
2. Set the numpy version < 2.0.0 in pyproject.toml