### PR TITLE
Use PTB for sounds instead of sounddevice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "packaging",
   "pillow",
   "psychopy",
-  "psychopy-sounddevice",
   "qtpy",
   "requests",
   "shapely",


### PR DESCRIPTION
- this is done by psychopy by default now
- remove psychopy-sounddevice from dependencies
- resolves 286